### PR TITLE
Add .txt to "show source" links.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -53,7 +53,6 @@ templates_path = ['_templates']
 
 # The suffix of source filenames.
 source_suffix = '.rst'
-html_sourcelink_suffix = '' # Don't add '.txt' to ipynb's.
 edit_on_github_project = 'clawpack/doc'
 edit_on_github_branch = 'master/doc'
 

--- a/gallery/conf.py
+++ b/gallery/conf.py
@@ -53,7 +53,6 @@ templates_path = ['../doc/_templates']
 
 # The suffix of source filenames.
 source_suffix = '.rst'
-html_sourcelink_suffix = '' # Don't add '.txt' to ipynb's.
 edit_on_github_project = 'clawpack/doc'
 edit_on_github_branch = 'master/doc'
 


### PR DESCRIPTION
So that they appear in browser rather than being downloaded.
This means that for notebooks the link will give you the JSON,
but that seems okay now that we also have the "view on Github" link.