### PR TITLE
Document new `fetch_remote_topo` and deprecation of `read_netcdf` and `etopo1_download`

### DIFF
--- a/doc/changes_to_master.rst
+++ b/doc/changes_to_master.rst
@@ -88,9 +88,9 @@ Changes to geoclaw
   See :ref:`topochanges`.
 
 - **Topography preprocessing attributes.**
-  :class:`~clawpack.geoclaw.topotools.Topography` now supports seven
+  :class:`~clawpack.geoclaw.topotools.Topography` now supports eight
   preprocessing attributes (``crop_extent``, ``coarsen``, ``buffer``,
-  ``align``, ``x_shift``, ``z_shift``, ``negate_z``) that are applied
+  ``align``, ``x_shift``, ``y_shift``, ``z_shift``, ``negate_z``) that are applied
   automatically when :meth:`~clawpack.geoclaw.topotools.Topography.read`
   loads a file.  See :ref:`setrun_topo_preprocessing` for the full table
   and :ref:`topotools` for usage examples and operation order.
@@ -111,7 +111,7 @@ Changes to geoclaw
   (a key of ``topotools.remote_topo_urls``), URL, or local path and reads it
   through the ``topo_type=4`` path, returning a
   :class:`~clawpack.geoclaw.topotools.Topography` with the requested
-  ``filter_region``/``coarsen``/``buffer``/``align`` applied.  The older
+  ``crop_extent``/``coarsen``/``buffer``/``align`` applied.  The older
   :func:`~clawpack.geoclaw.topotools.read_netcdf` is now a thin shim over it
   that emits a ``DeprecationWarning``.  In ``etopotools``,
   :func:`~clawpack.geoclaw.etopotools.fetch_etopo` is a convenience wrapper for
@@ -141,7 +141,7 @@ Changes to geoclaw
       topo.write('new.tt2', topo_type=2)
 
 - **New** ``topo.data`` **format.**
-  Each per-file block in ``topo.data`` now contains 9 lines (up from 2),
+  Each per-file block in ``topo.data`` now contains 10 lines (up from 2),
   recording all preprocessing attributes.  See :ref:`topodata_format` for
   the complete format specification.
 

--- a/doc/changes_to_master.rst
+++ b/doc/changes_to_master.rst
@@ -106,6 +106,21 @@ Changes to geoclaw
   are available without loading the elevation array.
   See :ref:`topotools` for an example.
 
+- **Remote-DEM fetch helper;** ``read_netcdf`` **deprecated.**
+  :func:`~clawpack.geoclaw.topotools.fetch_remote_topo` resolves a nickname
+  (a key of ``topotools.remote_topo_urls``), URL, or local path and reads it
+  through the ``topo_type=4`` path, returning a
+  :class:`~clawpack.geoclaw.topotools.Topography` with the requested
+  ``filter_region``/``coarsen``/``buffer``/``align`` applied.  The older
+  :func:`~clawpack.geoclaw.topotools.read_netcdf` is now a thin shim over it
+  that emits a ``DeprecationWarning``.  In ``etopotools``,
+  :func:`~clawpack.geoclaw.etopotools.fetch_etopo` is a convenience wrapper for
+  the etopo netCDF datasets, and
+  :func:`~clawpack.geoclaw.etopotools.etopo1_download` now always returns a
+  ``Topography``.  Because ``fetch_remote_topo`` uses the ``topo_type=4``
+  reader, the elevation variable must be in meters (or supply ``assume_units``
+  via ``nc_params``).  See :ref:`topo`.
+
 - **Python-owned priority ordering.**
   Topography files in ``topo.data`` are now sorted entirely in Python by
   :meth:`~clawpack.geoclaw.data.TopographyData._compute_priority_order`

--- a/doc/force_dry.rst
+++ b/doc/force_dry.rst
@@ -136,7 +136,7 @@ available from the NCEI thredds server:
 .. code:: ipython3
 
     path = 'https://www.ngdc.noaa.gov/thredds/dodsC/regional/puget_sound_13_mhw_2014.nc'
-    topo = topotools.fetch_remote_topo(path, filter_region=extent)
+    topo = topotools.fetch_remote_topo(path, crop_extent=extent)
 
 Plot the topo we downloaded:
 

--- a/doc/force_dry.rst
+++ b/doc/force_dry.rst
@@ -136,7 +136,7 @@ available from the NCEI thredds server:
 .. code:: ipython3
 
     path = 'https://www.ngdc.noaa.gov/thredds/dodsC/regional/puget_sound_13_mhw_2014.nc'
-    topo = topotools.read_netcdf(path, extent=extent)
+    topo = topotools.fetch_remote_topo(path, filter_region=extent)
 
 Plot the topo we downloaded:
 

--- a/doc/marching_front.rst
+++ b/doc/marching_front.rst
@@ -257,7 +257,7 @@ available from the NCEI thredds server:
 .. code:: ipython3
 
     path = 'https://www.ngdc.noaa.gov/thredds/dodsC/regional/puget_sound_13_mhw_2014.nc'
-    topo = topotools.read_netcdf(path, extent=extent)
+    topo = topotools.fetch_remote_topo(path, filter_region=extent)
 
 .. code:: ipython3
 

--- a/doc/marching_front.rst
+++ b/doc/marching_front.rst
@@ -257,7 +257,7 @@ available from the NCEI thredds server:
 .. code:: ipython3
 
     path = 'https://www.ngdc.noaa.gov/thredds/dodsC/regional/puget_sound_13_mhw_2014.nc'
-    topo = topotools.fetch_remote_topo(path, filter_region=extent)
+    topo = topotools.fetch_remote_topo(path, crop_extent=extent)
 
 .. code:: ipython3
 

--- a/doc/topo.rst
+++ b/doc/topo.rst
@@ -228,7 +228,7 @@ directly into GeoClaw.  As a convenience, you can use the
 <topotools_module.html#clawpack.geoclaw.topotools.fetch_remote_topo>`_ function
 (the older `topotools.read_netcdf` function is now deprecated in favor of it).
 Note that this also allows reading in only a subset of the data, both limiting
-the extent (via `filter_region`) and the resolution, e.g. by sampling every
+the extent (via `crop_extent`) and the resolution, e.g. by sampling every
 other point (by setting `coarsen=2`). This is particularly useful if you only
 want a subset of a huge
 online netCDF file (e.g. coastal DEMs at 1/3 arcsecond resolution are typically
@@ -240,9 +240,9 @@ etopo and a few other NOAA THREDDS datasets. This allows reading etopo
 30 arc-second data, for example, via::
 
     from clawpack.geoclaw import topotools
-    filter_region = [-135, -120, 38, 52]
+    crop_extent = [-135, -120, 38, 52]
     topo = topotools.fetch_remote_topo('etopo22_30sec',
-                                       filter_region=filter_region,
+                                       crop_extent=crop_extent,
                                        coarsen=1, verbose=True)
 
 A quick plot of the topography can then be created using::

--- a/doc/topo.rst
+++ b/doc/topo.rst
@@ -223,23 +223,27 @@ The `NOAA THREDDS server
 can be used to access a variety of topography data sets, including the etopo1
 global data set at 1 arcminute resolution and the etopo2 global data set at 2
 arcminute resolution.  These are available in netCDF format and can be read
-directly into GeoClaw.  As a convenience, you can use the `topotools.read_netcdf
-<topotools_module.html#clawpack.geoclaw.topotools.read_netcdf>`_ function.  Note
-that this also allows reading in only a subset of the data, both limiting the
-extent and the resolution, e.g. by sampling every other point (by setting
-`coarsen=2`). This is particularly useful if you only want a subset of a huge
+directly into GeoClaw.  As a convenience, you can use the
+`topotools.fetch_remote_topo
+<topotools_module.html#clawpack.geoclaw.topotools.fetch_remote_topo>`_ function
+(the older `topotools.read_netcdf` function is now deprecated in favor of it).
+Note that this also allows reading in only a subset of the data, both limiting
+the extent (via `filter_region`) and the resolution, e.g. by sampling every
+other point (by setting `coarsen=2`). This is particularly useful if you only
+want a subset of a huge
 online netCDF file (e.g. coastal DEMs at 1/3 arcsecond resolution are typically
 several gigabytes).  See :ref:`netcdf_input` for more details on working with
 netCDF files.
 
 The dictionary `topotools.remote_topo_urls` contains some useful URLs for
 etopo and a few other NOAA THREDDS datasets. This allows reading etopo
-60 arc-second data, for example, via::
+30 arc-second data, for example, via::
 
     from clawpack.geoclaw import topotools
-    extent = [-135, -120, 38, 52]
-    topo = topotools.read_netcdf('etopo22_60s', extent=extent,
-                                 coarsen=1, verbose=True)
+    filter_region = [-135, -120, 38, 52]
+    topo = topotools.fetch_remote_topo('etopo22_30sec',
+                                       filter_region=filter_region,
+                                       coarsen=1, verbose=True)
 
 A quick plot of the topography can then be created using::
 
@@ -253,14 +257,16 @@ and the topo can be saved as an ASCII raster topofile via, e.g.::
                grid_registration='llcenter', Z_format='%.1f')
 
 
-See `$CLAW/geoclaw/tests/test_etopo1.py` for one example, in which a very
-small patch from the global etopo1 database (which has 1 arcminute resolution)
-is downloaded at different resolutions.
+See the ETOPO integration tests in `$CLAW/geoclaw/tests/test_topotools.py`
+for an example, in which a very small patch from the global etopo1 database
+(which has 1 arcminute resolution) is downloaded at different resolutions.
 
-**Note:** Earlier versions of clawpack included `etopotools.py` providing a
-different way to download subsampled etopo1 topography.  That has been
-deprecated since the old way is no longer supported by NOAA and did not
-always do the subsampling properly.
+**Note:** The `etopotools.py` module provides `etopotools.fetch_etopo`, a thin
+convenience wrapper around `fetch_remote_topo` for the etopo netCDF datasets,
+along with a legacy `etopotools.etopo1_download` that fetches subsampled etopo1
+data from an older NOAA WCS endpoint.  That WCS endpoint is no longer reliably
+supported by NOAA, so reading the netCDF data directly via `fetch_remote_topo`
+/ `fetch_etopo` is preferred.
 
 **Note:** Data in the NOAA THREDDS server is referenced to NAVD88, not to MHW!
 

--- a/doc/topochanges.rst
+++ b/doc/topochanges.rst
@@ -109,6 +109,21 @@ Copied from :ref:`changes_to_master`
   are available without loading the elevation array.
   See :ref:`topotools` for an example.
 
+- **Remote-DEM fetch helper;** ``read_netcdf`` **deprecated.**
+  :func:`~clawpack.geoclaw.topotools.fetch_remote_topo` resolves a nickname
+  (a key of ``topotools.remote_topo_urls``), URL, or local path and reads it
+  through the ``topo_type=4`` path, returning a
+  :class:`~clawpack.geoclaw.topotools.Topography` with the requested
+  ``filter_region``/``coarsen``/``buffer``/``align`` applied.  The older
+  :func:`~clawpack.geoclaw.topotools.read_netcdf` is now a thin shim over it
+  that emits a ``DeprecationWarning``.  In ``etopotools``,
+  :func:`~clawpack.geoclaw.etopotools.fetch_etopo` is a convenience wrapper for
+  the etopo netCDF datasets, and
+  :func:`~clawpack.geoclaw.etopotools.etopo1_download` now always returns a
+  ``Topography``.  Because ``fetch_remote_topo`` uses the ``topo_type=4``
+  reader, the elevation variable must be in meters (or supply ``assume_units``
+  via ``nc_params``).  See :ref:`topo`.
+
 - **Python-owned priority ordering.**
   Topography files in ``topo.data`` are now sorted entirely in Python by
   :meth:`~clawpack.geoclaw.data.TopographyData._compute_priority_order`

--- a/doc/topochanges.rst
+++ b/doc/topochanges.rst
@@ -91,9 +91,9 @@ Copied from :ref:`changes_to_master`
 
 
 - **Topography preprocessing attributes.**
-  :class:`~clawpack.geoclaw.topotools.Topography` now supports seven
+  :class:`~clawpack.geoclaw.topotools.Topography` now supports eight
   preprocessing attributes (``crop_extent``, ``coarsen``, ``buffer``,
-  ``align``, ``x_shift``, ``z_shift``, ``negate_z``) that are applied
+  ``align``, ``x_shift``, ``y_shift``, ``z_shift``, ``negate_z``) that are applied
   automatically when :meth:`~clawpack.geoclaw.topotools.Topography.read`
   loads a file.  See :ref:`setrun_topo_preprocessing` for the full table
   and :ref:`topotools` for usage examples and operation order.
@@ -114,7 +114,7 @@ Copied from :ref:`changes_to_master`
   (a key of ``topotools.remote_topo_urls``), URL, or local path and reads it
   through the ``topo_type=4`` path, returning a
   :class:`~clawpack.geoclaw.topotools.Topography` with the requested
-  ``filter_region``/``coarsen``/``buffer``/``align`` applied.  The older
+  ``crop_extent``/``coarsen``/``buffer``/``align`` applied.  The older
   :func:`~clawpack.geoclaw.topotools.read_netcdf` is now a thin shim over it
   that emits a ``DeprecationWarning``.  In ``etopotools``,
   :func:`~clawpack.geoclaw.etopotools.fetch_etopo` is a convenience wrapper for
@@ -144,7 +144,7 @@ Copied from :ref:`changes_to_master`
       topo.write('new.tt2', topo_type=2)
 
 - **New** ``topo.data`` **format.**
-  Each per-file block in ``topo.data`` now contains 9 lines (up from 2),
+  Each per-file block in ``topo.data`` now contains 10 lines (up from 2),
   recording all preprocessing attributes.  See :ref:`topodata_format` for
   the complete format specification.
 

--- a/doc/topotools_module.rst
+++ b/doc/topotools_module.rst
@@ -16,13 +16,13 @@ topotools module for working with topography data
 Preprocessing attributes
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:class:`~clawpack.geoclaw.topotools.Topography` objects support seven
+:class:`~clawpack.geoclaw.topotools.Topography` objects support eight
 preprocessing attributes that are applied automatically by
 :meth:`~clawpack.geoclaw.topotools.Topography.read` in this order:
 
 1. ``negate_z`` — flip sign of Z (independent of ``topo_type < 0``).
 2. ``z_shift`` — add a constant to all non-missing Z values.
-3. ``x_shift`` — add a constant to all x coordinates.
+3. ``x_shift``, ``y_shift`` — add a constant to all x / y coordinates.
 4. ``crop_extent``, ``buffer``, ``align``, ``coarsen`` — crop and subsample
    via :meth:`~clawpack.geoclaw.topotools.Topography.crop`.
 

--- a/doc/tsunamidata.rst
+++ b/doc/tsunamidata.rst
@@ -28,7 +28,7 @@ modeling inundation.
   Note that ETOPO 2022 is the current version and ETOPO1 (often used in the
   past for GeoClaw modeling is obsolete). 
   Subsets of the 30 or 60 arc-second versions can be downloaded using
-  the `geoclaw.topotools.read_netcdf` function, see
+  the `geoclaw.topotools.fetch_remote_topo` function, see
   :ref:`topo_netcdf`.  For the 15 arcsecond data it is necessary
   to download one or more tiles from the `15 Arc-second Resolution Bedrock
   elevation netCDF catalog


### PR DESCRIPTION
The documentation here reflects the changes proposed in PR clawpack/geoclaw#726 that includes a unified mechanism for fetching remote topo files `fetch_remote_topo` and deprecates the two former functions that did some of this (`etopo1_download`) and read netCDF files in (`read_netcdf`).

Assisted-by: claude claude-opus-4-8